### PR TITLE
parseInt 16 -> unsigned number, readLong() -> signed int32

### DIFF
--- a/lib/gzip.js
+++ b/lib/gzip.js
@@ -257,7 +257,7 @@
 			}).join('');
 		}
 
-		crc = readLong(arr);
+		crc = readLong(arr) >>> 0;
 		if (crc !== parseInt(crc32(res), 16)) {
 			throw 'Checksum does not match';
 		}


### PR DESCRIPTION
fail to unzip buffer
new Buffer(JSON.stringify([{"name":"gold","value":331201}]))

