### PR TITLE
Remove unused parameter

### DIFF
--- a/lib/gzip.js
+++ b/lib/gzip.js
@@ -184,7 +184,7 @@
 		return out;
 	}
 
-	function unzip(data, options) {
+	function unzip(data) {
 		// start with a copy of the array
 		var arr = Array.prototype.slice.call(data, 0),
 			t,


### PR DESCRIPTION
2nd parameter of `unzip` looks unused. So I removed it to avoid confusion.
  